### PR TITLE
sardem-sarsen.py creates a STAC catalog for the stage-out and other minor fixes

### DIFF
--- a/nasa/ogc/workflows/process_sardem-sarsen_mlucas_nasa_ogc.cwl
+++ b/nasa/ogc/workflows/process_sardem-sarsen_mlucas_nasa_ogc.cwl
@@ -15,6 +15,10 @@ $graph:
       doc: STAC catalog folder
       label: catalog folder
       type: Directory
+    stac_asset_name:
+      doc: STAC asset name
+      label: asset name
+      type: string?
   outputs:
     out:
       type: Directory
@@ -25,6 +29,7 @@ $graph:
       in:
         bbox: bbox
         stac_catalog_folder: stac_catalog_folder
+        stac_asset_name: stac_asset_name
       out:
       - outputs_result
 - class: CommandLineTool
@@ -49,6 +54,12 @@ $graph:
       inputBinding:
         position: 2
         prefix: --stac_catalog_folder
+    stac_asset_name:
+      type: string?
+      default: PRODUCT
+      inputBinding:
+        position: 3
+        prefix: --stac_asset_name
   outputs:
     outputs_result:
       outputBinding:

--- a/nasa/ogc/workflows/process_sardem-sarsen_mlucas_nasa_ogc.cwl
+++ b/nasa/ogc/workflows/process_sardem-sarsen_mlucas_nasa_ogc.cwl
@@ -63,7 +63,7 @@ $graph:
   outputs:
     outputs_result:
       outputBinding:
-        glob: ./output*
+        glob: ./output/
       type: Directory
 $namespaces:
   s: https://schema.org/


### PR DESCRIPTION
- sardem-sarsen.py creates a STAC catalog for the stage-out
- input STAC asset name is a parameter in both sardem-sarsen.py and process_sardem-sarsen_mlucas_nasa_ogc.cwl
- input .SAFE file is unzipped in a folder within the working directory
- get_s1_grd_path returns absolute paths
- update the glob value of "outputs_result" in order to ensure that only the "./output/" folder is taken into account for the stage-out